### PR TITLE
[COM 212] Creating Mock User Data for UI Development

### DIFF
--- a/angular-app/src/app/models/interfaces/IAppointment.ts
+++ b/angular-app/src/app/models/interfaces/IAppointment.ts
@@ -1,3 +1,5 @@
+import { IUser } from "./IUser";
+
 export interface IAppointment {
     id?: number;
     date?: string;
@@ -9,6 +11,6 @@ export interface IAppointment {
     restrictions?: string;
     totalSlots?: number;
     tags?: string[];
-    registeredUsers: string[];
+    registeredUsers: string[] | IUser[];
     canceled?: boolean;
 }

--- a/angular-app/src/app/models/interfaces/IUser.ts
+++ b/angular-app/src/app/models/interfaces/IUser.ts
@@ -1,0 +1,21 @@
+/*
+    This model is pending a final revamp once we decide what kind of schema to use.
+    Email and role will be the only required fields, as we will default to email as display name.
+*/
+
+export enum UserRole {
+    'ADMIN',
+    'ORGANIZER',
+    'TALENT',
+    'PARTICIPANT',
+}
+
+export interface IUser {
+    email: string;
+    role: UserRole;
+    firstName?: string;
+    lastName?: string;
+    id?: string;
+    age?: number;
+    gender?: string;
+}

--- a/angular-app/src/app/models/mock/mock-admin-panel-users.ts
+++ b/angular-app/src/app/models/mock/mock-admin-panel-users.ts
@@ -1,0 +1,56 @@
+import { IUser, UserRole } from "../interfaces/IUser";
+
+/*
+    Migrated the mock data from the admin-panel-test.ts file to here
+*/
+
+const EMAIL: string[] = [
+    'example@gmail.com',
+  ];
+  
+const NAMES: string[] = [
+    'Matt',
+    'Daniel',
+    'Daniel',
+    'Ariel',
+    'Nero',
+    'Rozan',
+    'Dave',
+    'Theodore',
+    'Isla',
+    'Oliver',
+    'Isabella',
+    'Jasper',
+    'Cora',
+    'Levi',
+    'Violet',
+    'Arthur',
+    'Mia',
+    'Thomas',
+    'Elizabeth',
+];
+
+function getRandomRole<T>(IUser: T): T[keyof T] {
+    const roleValues = Object.keys(UserRole)
+        .map(n => Number.parseInt(n))
+        .filter(n => !Number.isNaN(n)) as unknown as T[keyof T][];
+    const randomIndex = Math.floor(Math.random() * roleValues.length);
+    const randomRoleValue = roleValues[randomIndex];
+    return randomRoleValue;
+}
+
+export const createNewUser = (id: number): IUser => {
+    const FirstName = 
+        NAMES[Math.round(Math.random() * (NAMES.length -1))] + ' ';
+    const LastName = 
+        NAMES[Math.round(Math.random() * (NAMES.length - 1))].charAt(0) + ' ';
+
+        return {
+            firstName: FirstName,
+            lastName: LastName,
+            email: EMAIL.toString(),
+            role: getRandomRole(UserRole),
+        };
+};
+
+export const AdminPanelTestUsers = Array.from({length: 100}, (_, k) => createNewUser(k + 1));

--- a/angular-app/src/app/models/mock/mock-appointments.ts
+++ b/angular-app/src/app/models/mock/mock-appointments.ts
@@ -1,4 +1,9 @@
 import { IAppointment } from "../interfaces/IAppointment";
+import { IUser, UserRole } from '../interfaces/IUser';
+import { MockParticipantList } from "./mock-users";
+
+const participants: IUser[] = MockParticipantList;
+const barber = { email: 'danielr@chameleon.com', role: UserRole.TALENT};
 
 export const MockAppointmentList: IAppointment[] = [
     {
@@ -9,7 +14,7 @@ export const MockAppointmentList: IAppointment[] = [
       title: "Appointment with Daniel", 
       location: "123 Main Street, Sacramento, CA 95810",
       description: "Men's Haircut (Premium)",
-      registeredUsers: ['Matt Crow'],
+      registeredUsers: [participants[0], barber],
     }, {
       id: 2, 
       date: "09/01/2022",
@@ -18,7 +23,7 @@ export const MockAppointmentList: IAppointment[] = [
       title: "Appointment with Daniel", 
       location: "123 Main Street, Sacramento, CA 95810",
       description: "Men's Haircut",
-      registeredUsers: ['Nero Tandel'],
+      registeredUsers: [participants[5], barber],
     }, {
       id: 3, 
       date: "09/01/2022",
@@ -27,7 +32,7 @@ export const MockAppointmentList: IAppointment[] = [
       title: "Appointment with Daniel", 
       location: "123 Main Street, Sacramento, CA 95810",
       description: "Men's Haircut",
-      registeredUsers: ['Ariel Carmargo'],
+      registeredUsers: [participants[4], barber],
     }, {
       id: 4, 
       date: "09/02/2022",
@@ -36,7 +41,7 @@ export const MockAppointmentList: IAppointment[] = [
       title: "Appointment with Daniel", 
       location: "123 Main Street, Sacramento, CA 95810",
       description: "Men's Haircut",
-      registeredUsers: ['Daniel Villavicencio'],
+      registeredUsers: [participants[1], barber],
     }, {
       id: 5, 
       date: "09/04/2022",
@@ -45,7 +50,7 @@ export const MockAppointmentList: IAppointment[] = [
       title: "Appointment with Daniel", 
       location: "123 Main Street, Sacramento, CA 95810",
       description: "Men's Haircut with Hot Towel",
-      registeredUsers: ['Dave Kaercher'],
+      registeredUsers: [participants[6], barber],
     }, {
       id: 6, 
       date: "09/05/2022",
@@ -54,7 +59,7 @@ export const MockAppointmentList: IAppointment[] = [
       title: "Appointment with Daniel", 
       location: "123 Main Street, Sacramento, CA 95810",
       description: "Men's Haircut with Beard Trim",
-      registeredUsers: ['Rojan Maharjan'],
+      registeredUsers: [participants[3], barber],
     }
 ];
 

--- a/angular-app/src/app/models/mock/mock-users.ts
+++ b/angular-app/src/app/models/mock/mock-users.ts
@@ -1,0 +1,235 @@
+import { IUser, UserRole } from "../interfaces/IUser";
+/*
+    This mock data is for the purposes of developing UI that's centered around displaying user data.
+    This file will be modified once our schemas and data modeling is done.
+*/
+
+export const MockAdminUserList: IUser[] = [
+    {
+        id: '1',
+        firstName: 'Matt',
+        lastName: 'Crow',
+        email: 'matt@chameleon.com',
+        role: UserRole.ADMIN
+    }, {
+        id: '2',
+        firstName: 'Daniel',
+        lastName: 'Villavicencio',
+        email: 'danielv@chameleon.com',
+        role: UserRole.ADMIN
+    }, {
+        id: '3',
+        firstName: 'Daniel',
+        lastName: 'Ramos',
+        email: 'danielr@chameleon.com',
+        role: UserRole.ADMIN,
+    }, {
+        id: '4',
+        firstName: 'Rojan',
+        lastName: 'Marharjan',
+        email: 'rojan@chameleon.com',
+        role: UserRole.ADMIN
+    }, {
+        id: '5',
+        firstName: 'Ariel',
+        lastName: 'Carmago',
+        email: 'ariel@chameleon.com',
+        role: UserRole.ADMIN
+    }, {
+        id: '6',
+        firstName: 'Nero',
+        lastName: 'Tandel',
+        email: 'nero@chameleon.com',
+        role: UserRole.ADMIN
+    }, {
+        id: '7',
+        firstName: 'Dave',
+        lastName: 'Kaercher',
+        email: 'dave@chameleon.com',
+        role: UserRole.ADMIN
+    }, 
+];
+
+export const MockParticipantList: IUser[] = [
+    {
+        id: '1',
+        firstName: 'Matt',
+        lastName: 'Crow',
+        email: 'matt@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, {
+        id: '2',
+        firstName: 'Daniel',
+        lastName: 'Villavicencio',
+        email: 'danielv@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, {
+        id: '3',
+        firstName: 'Daniel',
+        lastName: 'Ramos',
+        email: 'danielr@chameleon.com',
+        role: UserRole.PARTICIPANT,
+    }, {
+        id: '4',
+        firstName: 'Rojan',
+        lastName: 'Marharjan',
+        email: 'rojan@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, {
+        id: '5',
+        firstName: 'Ariel',
+        lastName: 'Carmago',
+        email: 'ariel@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, {
+        id: '6',
+        firstName: 'Nero',
+        lastName: 'Tandel',
+        email: 'nero@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, {
+        id: '7',
+        firstName: 'Dave',
+        lastName: 'Kaercher',
+        email: 'dave@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, 
+];
+
+export const MockTalentList: IUser[] = [
+    {
+        id: '1',
+        firstName: 'Matt',
+        lastName: 'Crow',
+        email: 'matt@chameleon.com',
+        role: UserRole.TALENT
+    }, {
+        id: '2',
+        firstName: 'Daniel',
+        lastName: 'Villavicencio',
+        email: 'danielv@chameleon.com',
+        role: UserRole.TALENT
+    }, {
+        id: '3',
+        firstName: 'Daniel',
+        lastName: 'Ramos',
+        email: 'danielr@chameleon.com',
+        role: UserRole.TALENT,
+    }, {
+        id: '4',
+        firstName: 'Rojan',
+        lastName: 'Marharjan',
+        email: 'rojan@chameleon.com',
+        role: UserRole.TALENT
+    }, {
+        id: '5',
+        firstName: 'Ariel',
+        lastName: 'Carmago',
+        email: 'ariel@chameleon.com',
+        role: UserRole.TALENT
+    }, {
+        id: '6',
+        firstName: 'Nero',
+        lastName: 'Tandel',
+        email: 'nero@chameleon.com',
+        role: UserRole.TALENT
+    }, {
+        id: '7',
+        firstName: 'Dave',
+        lastName: 'Kaercher',
+        email: 'dave@chameleon.com',
+        role: UserRole.TALENT
+    }, 
+];
+
+export const MockOrganizerUserList: IUser[] = [
+    {
+        id: '1',
+        firstName: 'Matt',
+        lastName: 'Crow',
+        email: 'matt@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '2',
+        firstName: 'Daniel',
+        lastName: 'Villavicencio',
+        email: 'danielv@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '3',
+        firstName: 'Daniel',
+        lastName: 'Ramos',
+        email: 'danielr@chameleon.com',
+        role: UserRole.ORGANIZER,
+    }, {
+        id: '4',
+        firstName: 'Rojan',
+        lastName: 'Marharjan',
+        email: 'rojan@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '5',
+        firstName: 'Ariel',
+        lastName: 'Carmago',
+        email: 'ariel@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '6',
+        firstName: 'Nero',
+        lastName: 'Tandel',
+        email: 'nero@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '7',
+        firstName: 'Dave',
+        lastName: 'Kaercher',
+        email: 'dave@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, 
+];
+
+export const MockGenericUserList: IUser[] = [
+    {
+        id: '1',
+        firstName: 'Matt',
+        lastName: 'Crow',
+        email: 'matt@chameleon.com',
+        role: UserRole.ADMIN
+    }, {
+        id: '2',
+        firstName: 'Daniel',
+        lastName: 'Villavicencio',
+        email: 'danielv@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '3',
+        firstName: 'Daniel',
+        lastName: 'Ramos',
+        email: 'danielr@chameleon.com',
+        role: UserRole.PARTICIPANT,
+    }, {
+        id: '4',
+        firstName: 'Rojan',
+        lastName: 'Marharjan',
+        email: 'rojan@chameleon.com',
+        role: UserRole.TALENT
+    }, {
+        id: '5',
+        firstName: 'Ariel',
+        lastName: 'Carmago',
+        email: 'ariel@chameleon.com',
+        role: UserRole.ORGANIZER
+    }, {
+        id: '6',
+        firstName: 'Nero',
+        lastName: 'Tandel',
+        email: 'nero@chameleon.com',
+        role: UserRole.PARTICIPANT
+    }, {
+        id: '7',
+        firstName: 'Dave',
+        lastName: 'Kaercher',
+        email: 'dave@chameleon.com',
+        role: UserRole.ADMIN
+    }, 
+];

--- a/angular-app/src/app/pages/admin-panel/admin-panel-test/admin-panel-test.component.html
+++ b/angular-app/src/app/pages/admin-panel/admin-panel-test/admin-panel-test.component.html
@@ -17,7 +17,7 @@
     <!-- Name Column -->
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> Name </th>
-      <td mat-cell *matCellDef="let row"> {{row.name}} </td>
+      <td mat-cell *matCellDef="let row"> {{row.firstName + row.lastName}} </td>
     </ng-container>
 
     <!-- Email Column -->

--- a/angular-app/src/app/pages/admin-panel/admin-panel-test/admin-panel-test.component.ts
+++ b/angular-app/src/app/pages/admin-panel/admin-panel-test/admin-panel-test.component.ts
@@ -2,47 +2,8 @@ import { AfterViewInit, Component, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-
-export interface UserData {
-  name: string;
-  email: string;
-  phone: string;
-  role: string;
-}
-
-/** Constants used to fill up our data base. */
-const ROLES: string[] = [
-  'Admin',
-  'Employee',
-
-];
-
-const EMAIL: string[] = [
-  'example@gmail.com',
-
-];
-
-const NAMES: string[] = [
-  'Matt',
-  'Daniel',
-  'Daniel',
-  'Ariel',
-  'Nero',
-  'Rozan',
-  'Dave',
-  'Theodore',
-  'Isla',
-  'Oliver',
-  'Isabella',
-  'Jasper',
-  'Cora',
-  'Levi',
-  'Violet',
-  'Arthur',
-  'Mia',
-  'Thomas',
-  'Elizabeth',
-];
+import { IUser } from 'src/app/models/interfaces/IUser';
+import { AdminPanelTestUsers } from 'src/app/models/mock/mock-admin-panel-users';
 
 @Component({
   selector: 'app-admin-panel-test',
@@ -51,17 +12,19 @@ const NAMES: string[] = [
 })
 export class AdminPanelTestComponent implements AfterViewInit {
   displayedColumns: string[] = ['name', 'email', 'phone', 'role', 'actions'];
-  dataSource: MatTableDataSource<UserData>;
+  dataSource: MatTableDataSource<IUser>;
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
 
   constructor() {
     // Create 100 users
-    const users = Array.from({length: 100}, (_, k) => createNewUser(k + 1));
+    // const users = Array.from({length: 100}, (_, k) => createNewUser(k + 1));
+    const myUsers = AdminPanelTestUsers;
+    console.log(myUsers);
 
     // Assign the data to the data source for the table to render
-    this.dataSource = new MatTableDataSource(users);
+    this.dataSource = new MatTableDataSource(myUsers);
   }
 
   ngAfterViewInit() {
@@ -77,20 +40,4 @@ export class AdminPanelTestComponent implements AfterViewInit {
       this.dataSource.paginator.firstPage();
     }
   }
-}
-
-/** Builds and returns a new User. */
-function createNewUser(id: number): UserData {
-  const name =
-    NAMES[Math.round(Math.random() * (NAMES.length - 1))] +
-    ' ' +
-    NAMES[Math.round(Math.random() * (NAMES.length - 1))].charAt(0) +
-    '.';
-
-  return {
-    name: name,
-    email: EMAIL.toString(),
-    phone: Math.floor(Math.random() * 10000000000).toString(),
-    role: ROLES[Math.round(Math.random() * (ROLES.length - 1))],
-  };
 }

--- a/angular-app/src/app/pages/appointments/appointment-details/appointment-details.component.html
+++ b/angular-app/src/app/pages/appointments/appointment-details/appointment-details.component.html
@@ -19,8 +19,8 @@
             </ng-container>
         
             <ng-container matColumnDef="client-name">
-                <th mat-header-cell *matHeaderCellDef> Client Name </th>
-                <td mat-cell *matCellDef="let element"> {{element.registeredUsers}} </td>
+                <th mat-header-cell *matHeaderCellDef> Client's Display Name (email) </th>
+                <td mat-cell *matCellDef="let element"> {{element.registeredUsers[0].email}} </td>
             </ng-container>
 
             <ng-container matColumnDef="date">


### PR DESCRIPTION
This pull request is meant to create a user data type (`IUser.ts`) to be used to create test data that we can use for UI development. This test data is helpful while our final schema for users and appointments is implemented and our back end can service all CRUD operations. 

I've also removed the test data from `admin-panel-test.ts` and moved it to another file `mock-admin-panel-users.ts.`

As per our discussion on Discord, I've made only the `email` and `role` fields mandatory while the rest will all be optional for now.
Emails will be our default display name for now.