### PR TITLE
COM 68 Admin Panel Saves New User

### DIFF
--- a/angular-app/src/app/models/interfaces/IUser.ts
+++ b/angular-app/src/app/models/interfaces/IUser.ts
@@ -1,10 +1,3 @@
-/*
-    This model is pending a final revamp once we decide what kind of schema to use.
-    Email and role will be the only required fields, as we will default to email as display name.
-*/
-
-import { IAppointment } from "./IAppointment";
-
 export enum UserRole {
     'ADMIN' = 'Admin',
     'ORGANIZER' = 'Organizer',
@@ -17,6 +10,6 @@ export interface IUser {
     email: string;
     role: UserRole;
     id?: string; 
-    appointments?: IAppointment[];
+    appointments?: string[];
     
 }

--- a/angular-app/src/app/pages/admin-panel/admin-panel/admin-panel.component.html
+++ b/angular-app/src/app/pages/admin-panel/admin-panel/admin-panel.component.html
@@ -107,7 +107,14 @@
             Guidelines: <br> New employee data should <strong>not</strong> include data of an existing employee.<br>
           </mat-card-subtitle>
           <mat-card-content>
-            <form [formGroup]="profileForm" class="form-container" (ngSubmit)="onClickSubmit(profileForm.value)">
+            <form [formGroup]="profileForm" class="form-container" id="ngForm" (ngSubmit)="onClickSubmit(profileForm.value)">
+              <div class="row">
+                <div class="col-md-6">
+                  <mat-form-field class="full-width">
+                    <input type="text" formControlName="displayName" matInput placeholder="Enter New Employee's Display Name" required>
+                  </mat-form-field>
+                </div>
+              </div>
               <div class="row">
                 <div class="col-md-6">
                   <mat-form-field class="full-width">
@@ -126,17 +133,16 @@
                 <mat-form-field class="full-width">
                   <mat-label>Select Employee's Role</mat-label>
                   <mat-select formControlName="role" matInput required>
-                    <mat-option value="Organizer">Organizer</mat-option>
-                    <mat-option value="Talent">Talent</mat-option>
+                    <mat-option value="ORGANIZER">Organizer</mat-option>
+                    <mat-option value="TALENT">Talent</mat-option>
                   </mat-select>
                 </mat-form-field>
               </div>
-              <input type="submit" value="Save">
             </form>
           </mat-card-content>
           <mat-card-actions>
-            <button mat-raised-button color="primary" (click)="onSave()">Save</button>
-            <button mat-raised-button color="secondary">Discard</button>
+            <button mat-raised-button color="primary" form="ngForm">Save</button>
+            <button mat-raised-button color="secondary" (click)="onDiscard()">Discard</button>
           </mat-card-actions>
         </mat-card>
 

--- a/angular-app/src/app/pages/admin-panel/admin-panel/admin-panel.component.ts
+++ b/angular-app/src/app/pages/admin-panel/admin-panel/admin-panel.component.ts
@@ -1,8 +1,7 @@
-//Author: Ariel Camargo
-import { Component } from "@angular/core";
-import { IUser } from "src/app/models/interfaces/IUser";
+import { Component, ViewChild } from "@angular/core";
+import { IUser, UserRole } from "src/app/models/interfaces/IUser";
 import { IUserResponse } from "src/app/models/interfaces/IUserResponse";
-import { FormBuilder, FormGroup } from "@angular/forms";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { UserService } from "src/app/services/UserService.service";
 
 @Component ({
@@ -12,7 +11,7 @@ import { UserService } from "src/app/services/UserService.service";
 })
 
 export class AdminPanelComponent {
-
+  
   myUserResponse: IUserResponse = { users: [] };
   displayedColumns: string[] = ['displayName', 'email', 'role'];
   selectedProfile: IUser | undefined;
@@ -29,6 +28,7 @@ export class AdminPanelComponent {
   }
 
   ngOnInit(): void {
+    // Ensures we are retrieving users from Vendia when this page loads.
     this.userService.getAllUsers().subscribe(
       (data) => {
         this.myUserResponse = data;
@@ -45,14 +45,19 @@ export class AdminPanelComponent {
   }
 
   onClickSubmit(data) {
-    const newProfile: IUser = {
-      displayName: data?.displayName ? data.displayName : data.email,
+    const newUser: IUser = {
+      displayName: data.displayName,
       email: data.email,
-      role: data.role,
+      role: data.role as UserRole,
     }
-    console.log("Clicking save: " + newProfile.displayName);
-    console.log("Clicking save: " + newProfile.email);
-    console.log("Clicking save: " + newProfile.role);
+
+    this.userService.createUser(newUser).subscribe(
+      data => console.log(data)
+    );
+  }
+
+  onDiscard() {
+    this.profileForm.reset();
   }
 
   onSave() {

--- a/angular-app/src/app/services/UserService.service.ts
+++ b/angular-app/src/app/services/UserService.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { catchError, Observable, tap, throwError } from 'rxjs';
+import { IUser } from '../models/interfaces/IUser';
 
 @Injectable()
 export class UserService {
@@ -12,6 +13,15 @@ export class UserService {
     // Function to fetch all the users from Vendia
     public getAllUsers(): Observable<any> {
         return this.httpClient.get(`${this.apiUrl}/users/getAllUsers`)
+            .pipe(
+                tap(console.log),
+                catchError(this.handleError)
+            );
+    }
+
+    // Function to create a new user and save in Vendia
+    public createUser(user: IUser): Observable<any> {
+        return this.httpClient.post(`${this.apiUrl}/users/createUser`, user)
             .pipe(
                 tap(console.log),
                 catchError(this.handleError)


### PR DESCRIPTION
This PR changes the Admin Panel by making the "Register a New Employee" form accept data and send it to Vendia. Consumes our `/api/users/createUser` end point.

- Note: you must be signed in to an account to use the feature.
- I haven't added validation checking in this PR, just make sure you're sending a complete form before clicking on "Save" to avoid a post error.
- UI styling is temporary, just getting the functionality up and running.


![PRB](https://user-images.githubusercontent.com/58965151/194214943-62af6e04-f0f5-49a9-ad75-dae4345a12f6.JPG)
