### PR TITLE
[COM 250] Loading the Landing Page will Invoke Login Modal Logic

### DIFF
--- a/angular-app/src/app/app-routing.module.ts
+++ b/angular-app/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { AdminPanelComponent} from "./pages/admin-panel/admin-panel/admin-panel.
 import { AdminPanelTestComponent } from "./pages/admin-panel/admin-panel-test/admin-panel-test.component";
 import { AppointmentCreateFormComponent } from './pages/appointments/appointment-create-form/appointment-create-form.component';
 import { AppointmentDetailsComponent } from './pages/appointments/appointment-details/appointment-details.component';
+import { AppointmentListComponent } from './pages/appointments/appointment-list/appointment-list.component';
 import { BookingPageComponent} from "./pages/appointments/booking-page/booking-page.component";
 import { CalenderViewComponent } from './pages/appointments/appointment-calender/calender-view/calender-view.component';
 import { LandingPageConfigurationComponent } from "./pages/admin-configuration/landing-page-configuration/landing-page-configuration.component";
@@ -19,7 +20,8 @@ const routes: Routes = [
   { path: 'admin-configuration', component: AdminConfigurationComponent },
   { path: 'admin-panel', component: AdminPanelComponent },
   { path: 'admin-panel-test', component: AdminPanelTestComponent },
-  { path: 'appointment-create', component: AppointmentCreateFormComponent },
+  { path: 'appointment-list',component:AppointmentListComponent},
+  { path: 'appointment-creation',component:AppointmentCreateFormComponent},
   { path: 'appointment-details', component: AppointmentDetailsComponent },
   { path: 'calender-view',component: CalenderViewComponent },
   { path: 'booking-page', component: BookingPageComponent },

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AppointmentCreateFormComponent } from './pages/appointments/appointment
 import { AppointmentDetailsComponent } from './pages/appointments/appointment-details/appointment-details.component';
 import { AppointmentListComponent } from './pages/appointments/appointment-list/appointment-list.component';
 import { AppRoutingModule } from './app-routing.module';
+import { AuthenticationService } from './services/AuthenticationService.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserModule } from '@angular/platform-browser';
 import { BookingPageComponent} from './pages/appointments/booking-page/booking-page.component';
@@ -124,8 +125,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
       { path: 'admin-panel', component: AdminPanelComponent },
       { path: 'admin-panel-test', component: AdminPanelComponent },
       { path: 'appointment-details', component: AppointmentDetailsComponent },
-      {path:'appointment-list',component:AppointmentListComponent},
-      {path:'appointment-creation',component:AppointmentCreateFormComponent},
+      { path: 'appointment-list',component:AppointmentListComponent},
+      { path: 'appointment-creation',component:AppointmentCreateFormComponent},
       { path: 'booking-page', component: BookingPageComponent },
       { path: 'calender-view',component: CalenderViewComponent },
       { path: 'landing-page-component', component: LandingPageConfigurationComponent },
@@ -133,7 +134,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
       { path: 'sign-in', component: SignInFormComponent },
       { path: 'site-header', component: SiteHeaderComponent },
 
-      {path:'**',component:PageNotFoundComponent}
+      { path: '**', component: PageNotFoundComponent }
     ]),
     CalendarModule.forRoot({
         provide:DateAdapter,
@@ -142,7 +143,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   ],
 
   providers: [
-
+    AuthenticationService,
     UserService
   ],
   bootstrap: [AppComponent]

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.html
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.html
@@ -9,7 +9,9 @@
   </mat-toolbar-row>
 </mat-toolbar>
 
-<app-nav></app-nav>
+<div *ngIf="(isAuthenticatedValue && isRegisteredValue)">
+  <app-nav></app-nav>
+</div>
 
 <div class="main-content">
   <div class="card">

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.ts
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.ts
@@ -1,18 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { AuthenticationService } from 'src/app/services/AuthenticationService.service';
 import { DomSanitizer } from "@angular/platform-browser";
 import { HttpClient } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconRegistry } from "@angular/material/icon";
 import { SignupModalComponent } from 'src/app/theme/modals/signup-modal/signup-modal.component';
 
+
 @Component({
   selector: 'app-splash',
   templateUrl: './splash.component.html',
   styleUrls: ['./splash.component.css']
 })
-export class SplashComponent {
+export class SplashComponent implements OnInit {
 
-  constructor(private http: HttpClient, private matIconRegistry: MatIconRegistry, private domSanitizer : DomSanitizer, public dialog: MatDialog) {
+  public isRegisteredValue: boolean;
+  public isAuthenticatedValue: boolean;
+  public shouldDisplayModal: boolean;
+  public userEmail: string;
+
+  constructor(private http: HttpClient, private matIconRegistry: MatIconRegistry, private domSanitizer : DomSanitizer, public dialog: MatDialog, private authenticationService: AuthenticationService) {
     this.matIconRegistry.addSvgIcon(
       "calendar",
       this.domSanitizer.bypassSecurityTrustResourceUrl("../assets/images/icons8-calendar.svg")
@@ -37,18 +44,51 @@ export class SplashComponent {
       'edit',
       this.domSanitizer.bypassSecurityTrustResourceUrl("../assets/images/icons8-edit.svg")
     );
-    http.get<{content: string}>("/custom/splash").subscribe((obj: {content: string})=>{
-      const e = <HTMLElement>document.querySelector("#splash");
-      e.innerHTML = obj.content; // replace element content
+  }
+
+  ngOnInit(): void {
+    this.checkIfAuthenticated();
+    this.checkIfRegisteredWithVendia();
+    this.shouldDisplayModal = (this.isAuthenticatedValue && this.isRegisteredValue === false);
+  }
+
+  getUserEmail() {
+    this.authenticationService.getPrincipal().subscribe(
+      data => { 
+        this.userEmail = data.valueOf(); 
+        this.updateShouldDisplayModal(this.isRegisteredValue, this.userEmail);
+    });  
+  }
+
+  checkIfAuthenticated() {
+    this.authenticationService.isAuthenticated().subscribe(
+      data => { 
+        this.isAuthenticatedValue = data;
     });
   }
 
-  displayModal(): void {
-    const dialogRef = this.dialog.open(SignupModalComponent, { disableClose: true });
-
-    dialogRef.afterClosed().subscribe(result => {
-      console.log("The modal was closed");
+  checkIfRegisteredWithVendia() {
+    this.authenticationService.isUserRegistered().subscribe(
+      data => { 
+        this.isRegisteredValue = data;
+        this.getUserEmail();
+        this.updateShouldDisplayModal(this.isRegisteredValue, this.userEmail); 
     });
   }
+
+
+  updateShouldDisplayModal(newRegisteredValue: boolean, email: string): void {
+    if(this.shouldDisplayModal = (this.isAuthenticatedValue && newRegisteredValue === false) && email !== undefined){
+      this.displayModal(email);
+    }
+  }
+
+  displayModal(email: string): void {
+    console.log("About to build the modal. The value of the email here is: " + email);
+    const dialogRef = this.dialog.open(SignupModalComponent, { 
+      disableClose: true,
+      data: { userEmailValue: email } 
+    });
+  } 
 
 }

--- a/angular-app/src/app/services/AuthenticationService.service.ts
+++ b/angular-app/src/app/services/AuthenticationService.service.ts
@@ -1,0 +1,44 @@
+import { catchError, Observable, tap, throwError } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class AuthenticationService {
+
+    private readonly apiUrl = '/api/v2/auth';
+
+    constructor (private httpClient: HttpClient) { }
+
+    // Returns the email address of the authenticated user
+    public getPrincipal(): Observable<string> {
+        return this.httpClient.get(`${this.apiUrl}/getPrincipal`, { responseType: 'text'})
+            .pipe(
+                tap(console.log),
+                catchError(this.handleError)
+            );
+    }
+
+    // Checks Vendia to see if the authenticated user exists in the User table
+    public isUserRegistered(): Observable<any> {
+        return this.httpClient.get(`${this.apiUrl}/isUserRegistered`)
+            .pipe(
+                tap(console.log),
+                catchError(this.handleError)
+            );
+    }
+
+    // Returns true if the user is authenticated
+    public isAuthenticated(): Observable<any> {
+        return this.httpClient.get(`${this.apiUrl}/isAuthenticated`, {responseType: 'text'})
+            .pipe(
+                tap(console.log),
+                catchError(this.handleError)
+            );
+    }   
+
+    private handleError(error: HttpErrorResponse): Observable<never> {
+        console.log(error);
+        return throwError(`An error occured - Error code: ${error.status}`);
+    }
+
+}

--- a/angular-app/src/app/services/UserService.service.ts
+++ b/angular-app/src/app/services/UserService.service.ts
@@ -6,13 +6,13 @@ import { IUser } from '../models/interfaces/IUser';
 @Injectable()
 export class UserService {
 
-    private readonly apiUrl = '/api';
+    private readonly apiUrl = '/api/v2/users';
 
     constructor(private httpClient: HttpClient) { }
 
     // Function to fetch all the users from Vendia
     public getAllUsers(): Observable<any> {
-        return this.httpClient.get(`${this.apiUrl}/users/getAllUsers`)
+        return this.httpClient.get(`${this.apiUrl}/getAllUsers`)
             .pipe(
                 tap(console.log),
                 catchError(this.handleError)
@@ -21,7 +21,7 @@ export class UserService {
 
     // Function to create a new user and save in Vendia
     public createUser(user: IUser): Observable<any> {
-        return this.httpClient.post(`${this.apiUrl}/users/createUser`, user)
+        return this.httpClient.post(`${this.apiUrl}/createUser`, user)
             .pipe(
                 tap(console.log),
                 catchError(this.handleError)

--- a/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.html
+++ b/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.html
@@ -33,7 +33,7 @@
                 <div class="row">
                     <div class="col-md-6">
                         <p class="content-text">We will associate the following email to this account:</p>
-                        <p class="content-text">*Email will go here*</p>
+                        <p class="content-text"> {{ userEmailValue }} </p>
                     </div>
                 </div>
             </form>

--- a/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
+++ b/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
@@ -1,7 +1,7 @@
 import { AbstractControl, FormControl, FormGroup, Validators } from "@angular/forms";
 import { IUser, UserRole } from 'src/app/models/interfaces/IUser';
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-signup-modal',
@@ -11,12 +11,15 @@ import { MatDialogRef } from '@angular/material/dialog';
 export class SignupModalComponent {
 
   profileForm: FormGroup;
+  userEmailValue: string;
 
-  constructor (public dialogRef: MatDialogRef<SignupModalComponent>) {
+  constructor (@Inject(MAT_DIALOG_DATA) public data: { userEmailValue: string}, public dialogRef: MatDialogRef<SignupModalComponent>) {
     this.profileForm = new FormGroup({
       displayName: new FormControl ('', [ Validators.required ]),
       confirmDisplayName: new FormControl('')
-    }, { validators: validateDisplayName })
+    }, { validators: validateDisplayName });
+
+    this.userEmailValue = data.userEmailValue;
   }
 
   getDisplayName() {
@@ -30,9 +33,10 @@ export class SignupModalComponent {
   onClickSubmit(data): void {
     const newUser: IUser = {
       displayName: data.displayName,
-      email: "Test@email.com",
-      role: UserRole.PARTICIPANT
+      email: this.userEmailValue,
+      role: "PARTICIPANT" as UserRole
     }
+    console.log("Created user with displayName: " + newUser.displayName);
   }
 
   onNoClick(): void {

--- a/src/main/java/com/compilercharisma/chameleonbusinessstudio/controller/AuthenticationController.java
+++ b/src/main/java/com/compilercharisma/chameleonbusinessstudio/controller/AuthenticationController.java
@@ -1,11 +1,26 @@
 package com.compilercharisma.chameleonbusinessstudio.controller;
 
+import com.compilercharisma.chameleonbusinessstudio.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
 
 @RestController
+@Slf4j
+@RequestMapping(path="/api/v2/auth")
 public class AuthenticationController {
+
+    private final UserService userService;
+
+    public AuthenticationController(UserService userService){
+        this.userService = userService;
+    }
 
     /**
      * Gets the currently logged-in user's email from the Authentication object
@@ -17,4 +32,32 @@ public class AuthenticationController {
     public String getPrincipal(Authentication authentication) {
         return ((OAuth2AuthenticationToken) authentication).getPrincipal().getAttribute("email");
     }
+
+    /**
+     * Returns true if the user is properly authenticated
+     *
+     * @param authentication Method of Authentication, e.g. Google OAuth2.0
+     * @return true if the user is authenticated, false otherwise
+     */
+    @GetMapping("/isAuthenticated")
+    public boolean isAuthenticated(Authentication authentication) {
+        return authentication.isAuthenticated();
+    }
+
+    /**
+     * Returns true if the currently authenticated user has a user in Vendia,
+     * else returns false
+     *
+     * @param authentication Authentication object (has the OAuth2.0 token)
+     * @return {@link Boolean}
+     */
+    @GetMapping("/isUserRegistered")
+    public Mono<ResponseEntity<Boolean>> isUserRegistered(Authentication authentication){
+        var email = ((OAuth2AuthenticationToken) authentication).getPrincipal().getAttribute("email");
+        log.info("Checking to see if user with email [{}] is registered in Vendia", email);
+        return Mono.just(Objects.requireNonNull(email))
+                .flatMap(s -> userService.isRegistered((String) s))
+                .map(bool -> new ResponseEntity<>(bool, HttpStatus.OK));
+    }
+
 }

--- a/src/main/java/com/compilercharisma/chameleonbusinessstudio/controller/UserController.java
+++ b/src/main/java/com/compilercharisma/chameleonbusinessstudio/controller/UserController.java
@@ -81,20 +81,4 @@ public class UserController {
                 .doOnError(u -> log.error("Something unexpected happened!"));
     }
 
-    /**
-     * Returns true if the currently authenticated user has a user in Vendia,
-     * else returns false
-     *
-     * @param authentication Authentication object (has the OAuth2.0 token)
-     * @return {@link Boolean}
-     */
-    @GetMapping("/isUserRegistered")
-    public Mono<ResponseEntity<Boolean>> isUserRegistered(Authentication authentication){
-        var email = ((OAuth2AuthenticationToken) authentication).getPrincipal().getAttribute("email");
-        log.info("Checking to see if user with email [{}] is registered in Vendia", email);
-        return Mono.just(Objects.requireNonNull(email))
-                .flatMap(s -> userService.isRegistered((String) s))
-                .map(bool -> new ResponseEntity<>(bool, HttpStatus.OK));
-    }
-
 }


### PR DESCRIPTION
This is the first PR for our login flow. This creates `AuthenticationService.service.ts` to get authentication information from our server to implement the logic needed to invoke our sign in prompt (which is in the form of a modal overlay).

- Navigation bar is removed when unauthenticated and when authenticated but not registered in Vendia
- Once you sign into an account with an account that is registered in Vendia (we can use ChameleonBusinessStudio@gmail.com) for example, the navigation bar will appear and you won't get the login modal appearing anymore.

Example of a session where I am authenticated with a Google account that is not registered in Vendia: 
![PR1](https://user-images.githubusercontent.com/58965151/195716103-bcb267a6-1043-4306-a50d-18ebf019fb68.JPG)

Example of a session where I am authenticated with a Google account and also registered in Vendia (notice nav bar appears):
![PR2](https://user-images.githubusercontent.com/58965151/195716192-3a78acca-1a0c-4217-b632-df033d29d3fa.JPG)
