### PR TITLE
[Bugfix] Security Configuration for user registration flow

### DIFF
--- a/src/main/java/com/compilercharisma/chameleonbusinessstudio/config/SecurityConfiguration.java
+++ b/src/main/java/com/compilercharisma/chameleonbusinessstudio/config/SecurityConfiguration.java
@@ -20,6 +20,7 @@ public class SecurityConfiguration {
                 .oauth2Login()
                 .and()
                 .authorizeExchange()
+                .pathMatchers(HttpMethod.POST,   "/api/v1/users").authenticated()                // this will be used for the log in flow after a user is authenticated
                 .pathMatchers(HttpMethod.GET,    "/api/v1/**").authenticated()                   // by default, allow any logged-in user to GET
                 .pathMatchers(HttpMethod.POST,   "/api/v1/**").access(userAuthorizationManager)  // by default, only authorized users can POST
                 .pathMatchers(HttpMethod.PUT,    "/api/v1/**").access(userAuthorizationManager)  // by default, only authorized users can PUT

--- a/src/main/java/com/compilercharisma/chameleonbusinessstudio/config/SecurityConfiguration.java
+++ b/src/main/java/com/compilercharisma/chameleonbusinessstudio/config/SecurityConfiguration.java
@@ -20,16 +20,10 @@ public class SecurityConfiguration {
                 .oauth2Login()
                 .and()
                 .authorizeExchange()
-                .pathMatchers(HttpMethod.POST, "/api/v1/users").authenticated()                // this will be used for the log in flow after a user is authenticated
-                .pathMatchers(HttpMethod.GET, "/api/v1/**").authenticated()                   // by default, allow any logged-in user to GET
-                .pathMatchers(HttpMethod.POST, "/api/v1/**").access(userAuthorizationManager)  // by default, only authorized users can POST
-                .pathMatchers(HttpMethod.PUT, "/api/v1/**").access(userAuthorizationManager)  // by default, only authorized users can PUT
-                .pathMatchers(HttpMethod.DELETE, "/api/v1/**").access(userAuthorizationManager)  // by default, only authorized users can DELETE
+                .pathMatchers(HttpMethod.POST, "/api/v1/users").authenticated() // allow logged-in users to register themselves
                 .pathMatchers(HttpMethod.POST, "/api/v1/appointments/book-me").authenticated() // allow any role to book-me
-                .pathMatchers(HttpMethod.GET, "/api/v1/auth/principal").permitAll()           // not sure if this will crash?
-                .pathMatchers(HttpMethod.GET, "/api/v1/auth/isAuthenticated").permitAll()     // crash?
-                .pathMatchers(HttpMethod.GET, "/api/v1/auth/isUserRegistered").permitAll()    // crash?
-                .pathMatchers(HttpMethod.GET, "/api/v1/config/**").permitAll()                // need to allow unauthenticated users
+                .pathMatchers(HttpMethod.POST, "/api/v1/appointments/unbook-me").authenticated() // allow any role to unbook-me
+                .pathMatchers(HttpMethod.GET, "/api/v1/config/**").permitAll() // need to allow unauthenticated users
                 .pathMatchers(
                         "/",
                         "/index",
@@ -43,8 +37,11 @@ public class SecurityConfiguration {
                         "/site-header",
                         "/assets/images/**.svg")
                 .permitAll()
-                .anyExchange()
-                .authenticated()
+                .pathMatchers(HttpMethod.GET, "/api/v1/**").authenticated() // by default, allow any logged-in user to GET
+                .pathMatchers(HttpMethod.POST, "/api/v1/**").access(userAuthorizationManager) // by default, only authorized users can POST
+                .pathMatchers(HttpMethod.PUT, "/api/v1/**").access(userAuthorizationManager) // by default, only authorized users can PUT
+                .pathMatchers(HttpMethod.DELETE, "/api/v1/**").access(userAuthorizationManager) // by default, only authorized users can DELETE
+                .anyExchange().authenticated()
                 .and()
                 .cors().configurationSource(cs -> new CorsConfiguration().applyPermitDefaultValues())
                 .and()


### PR DESCRIPTION
This PR unblocks the user registration flow, basically I added an extra layer on top of all the previous ones that allows an authenticated user (after logging in with Google) to access the `POST /api/v1/users/` that creates a user in Vendia