### PR TITLE
[COM-237] Update Vendia schema and user so they can have a phone number

### DIFF
--- a/src/main/java/com/compilercharisma/chameleonbusinessstudio/dto/User.java
+++ b/src/main/java/com/compilercharisma/chameleonbusinessstudio/dto/User.java
@@ -38,6 +38,11 @@ public class User implements Serializable {
     private UserRole role;
 
     /**
+     * The phone number of the user
+     */
+    private String phoneNumber;
+
+    /**
      * List of appointment ids that the user has
      */
     private List<String> appointments;

--- a/src/test/groovy/com/compilercharisma/chameleonbusinessstudio/integration/UserControllerITSpec.groovy
+++ b/src/test/groovy/com/compilercharisma/chameleonbusinessstudio/integration/UserControllerITSpec.groovy
@@ -26,7 +26,7 @@ class UserControllerITSpec extends BaseITSpec{
                 .withHeader("Authorization", equalTo(VENDIA_API_KEY))
                 .withHeader("Content-Type", equalTo("application/json"))
                 .withHeader("Accept", equalTo("application/json, application/graphql+json"))
-                .withRequestBody(equalTo("{\"query\":\"query { list_UserItems { _UserItems { _id email displayName appointments } } }\"}"))
+                .withRequestBody(equalTo("{\"query\":\"query { list_UserItems { _UserItems { _id email displayName role appointments } } }\"}"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
This PR basically sets up the `User.dto` so that it has a `phoneNumber` attribute, in the near future however, I will utilize Twilio's API in order to validate whether the phone number is real or not