### PR TITLE
COM 267 Display Booked Appointment Widget On Talent's Dashboard

### DIFF
--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -70,6 +70,7 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { EventWidgetComponent } from './theme/widgets/event-widget/event-widget.component';
+import { BookedApptsWidgetComponent } from './theme/widgets/booked-appts-widget/booked-appts-widget.component';
 
 
 @NgModule({
@@ -102,6 +103,7 @@ import { EventWidgetComponent } from './theme/widgets/event-widget/event-widget.
     AdminNavComponent,
     ParticipantNavComponent,
     EventWidgetComponent,
+    BookedApptsWidgetComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { AppointmentDetailsComponent } from './pages/appointments/appointment-de
 import { AppointmentListComponent } from './pages/appointments/appointment-list/appointment-list.component';
 import { AppRoutingModule } from './app-routing.module';
 import { AuthenticationService } from './services/AuthenticationService.service';
+import { BookedApptsWidgetComponent } from './theme/widgets/booked-appts-widget/booked-appts-widget.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserModule } from '@angular/platform-browser';
 import { BookingPageComponent} from './pages/appointments/booking-page/booking-page.component';
@@ -70,7 +71,6 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { EventWidgetComponent } from './theme/widgets/event-widget/event-widget.component';
-import { BookedApptsWidgetComponent } from './theme/widgets/booked-appts-widget/booked-appts-widget.component';
 
 
 @NgModule({
@@ -84,6 +84,7 @@ import { BookedApptsWidgetComponent } from './theme/widgets/booked-appts-widget/
     AppointmentCreateFormComponent,
     AppointmentDetailsComponent,
     AppointmentListComponent,
+    BookedApptsWidgetComponent,
     BookingPageComponent,
     CalenderViewComponent,
     CustomBannerDirective,
@@ -103,7 +104,6 @@ import { BookedApptsWidgetComponent } from './theme/widgets/booked-appts-widget/
     AdminNavComponent,
     ParticipantNavComponent,
     EventWidgetComponent,
-    BookedApptsWidgetComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/angular-app/src/app/models/interfaces/IAppointment.ts
+++ b/angular-app/src/app/models/interfaces/IAppointment.ts
@@ -3,8 +3,8 @@ import { IUser } from "./IUser";
 export interface IAppointment {
     id?: number;
     title: string;
-    startTime: Date | string;
-    endTime: Date | string;
+    startTime: Date | string | number[];
+    endTime: Date | string | number[];
     date?: string;
     location: string;
     description: string;

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.css
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.css
@@ -26,22 +26,36 @@ mat-toolbar{
 .main-content{
   display: flex;
   flex-flow: row wrap;
-  justify-content: space-between;
+  justify-content: center;
   scroll-behavior: smooth;
   align-items: center;
-  justify-content: center;
   alignment: center;
   margin: auto;
 }
 
-.talent-toolbar{
-  background: #ff4081;
+.second-toolbar{
+  background: #12002e;
   margin-bottom: 50px;
+  height: 5px;
   width: 100%;
 }
 
 .talent-content{
   display: flex;
+  justify-content: space-around;
+}
+
+.welcome-message{
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.welcome-text{
+  font-family: 'Lato';
+  font-size: 28px;
+  text-align: center;
 }
 
 .event-card {
@@ -103,4 +117,12 @@ mat-toolbar{
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   background-color: #12002e;
+}
+
+.event-widget{
+  margin: 20px 20px 20px 20px;
+}
+
+.booked-appt-widget{
+  margin: 20px 20px 20px 20px;
 }

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.css
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.css
@@ -26,12 +26,22 @@ mat-toolbar{
 .main-content{
   display: flex;
   flex-flow: row wrap;
+  justify-content: space-between;
   scroll-behavior: smooth;
   align-items: center;
   justify-content: center;
-  padding: 20px;
   alignment: center;
   margin: auto;
+}
+
+.talent-toolbar{
+  background: #ff4081;
+  margin-bottom: 50px;
+  width: 100%;
+}
+
+.talent-content{
+  display: flex;
 }
 
 .event-card {
@@ -73,4 +83,24 @@ mat-toolbar{
   text-align: center;
   min-height: 80px;
   min-width: 300px;
+}
+
+.top-line{
+  height: 10px;
+  margin-top: -1px;
+  margin-right: -1px;
+  margin-left: -1px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  background-color: #12002e;
+}
+
+.bottom-line{
+  height: 10px;
+  margin-top: 1px;
+  margin-right: 1px;
+  margin-left: 1px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  background-color: #12002e;
 }

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.css
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.css
@@ -120,9 +120,9 @@ mat-toolbar{
 }
 
 .event-widget{
-  margin: 20px 20px 20px 20px;
+  margin: 30px 30px 30px 30px;
 }
 
 .booked-appt-widget{
-  margin: 20px 20px 20px 20px;
+  margin: 30px 30px 30px 30px;
 }

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.html
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.html
@@ -43,30 +43,25 @@
   </div>
 </div>
 
-<div *ngIf="(isAuthenticatedValue && isRegisteredValue) && (currentUser.role === 'TALENT')" class="main-content">
-  <div class="card">
-    <h2 class="label">Welcome Back {{ currentUser.displayName }}!</h2>
-    <p class="description">
-      You are a talent.<br>
-      Our project provides an open-source scheduling template that can be tailored to an individual
-      or to an organization's specific needs, just like a Chameleon!
-    </p>
-    <div class="icon-wrapper">
-      <mat-icon class="main-icon" svgIcon="checkAll"></mat-icon>
+<!-- Dynamic Rendering for Talent Accounts -->
+<div *ngIf="(isAuthenticatedValue && isRegisteredValue) && (currentUser.role === 'TALENT')" class="main-content">  
+  <mat-toolbar class="talent-toolbar">
+    <span>Welcome Back {{ currentUser.displayName }}!</span>
+  </mat-toolbar>
+
+
+
+  <div class="talent-content">  
+    <div>
+      <app-event-widget></app-event-widget>
     </div>
+      
+    <div>
+      <app-booked-appts-widget></app-booked-appts-widget>
+    </div>
+
   </div>
 
-<div>
-  <app-event-widget></app-event-widget>
-</div>
-    
-  <mat-card class="upcoming-appointments-card">
-    <mat-card-title>Upcoming Booked Appointments</mat-card-title>
-    <mat-card-subtitle>Name of the Appointment</mat-card-subtitle>
-    <mat-card-content>
-      First 10 appointments in this scrollable widget. Coming soon!
-    </mat-card-content>
-  </mat-card>
 
 </div>
 

--- a/angular-app/src/app/pages/dashboard/splash/splash.component.html
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.html
@@ -45,18 +45,20 @@
 
 <!-- Dynamic Rendering for Talent Accounts -->
 <div *ngIf="(isAuthenticatedValue && isRegisteredValue) && (currentUser.role === 'TALENT')" class="main-content">  
-  <mat-toolbar class="talent-toolbar">
-    <span>Welcome Back {{ currentUser.displayName }}!</span>
+  <mat-toolbar class="second-toolbar">
   </mat-toolbar>
 
-
+  <div class="welcome-message">
+    <p class="welcome-text">Welcome Back {{ currentUser.displayName }}!</p>
+  </div>
+  
 
   <div class="talent-content">  
-    <div>
+    <div class="event-widget">
       <app-event-widget></app-event-widget>
     </div>
       
-    <div>
+    <div class="booked-appts-widget">
       <app-booked-appts-widget></app-booked-appts-widget>
     </div>
 

--- a/angular-app/src/app/services/DateManager.ts
+++ b/angular-app/src/app/services/DateManager.ts
@@ -125,6 +125,14 @@ export class DateManager {
 
 
         return newDate + "T" + newTime; 
+    }
 
+    public arrayToDate(date: number[]): Date {
+        let year = date[0];
+        let month = date[1];
+        let day = date[2];
+        let hour = date[3];
+        let minute = date[4];
+        return new Date(year, month - 1, day, hour, minute);
     }
 }

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.css
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.css
@@ -1,6 +1,4 @@
 .main-container{
-    margin: 15px;
-    margin-left: 50px;
     height: 450px;
     width: 600px;
     text-align: center;

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.css
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.css
@@ -1,0 +1,36 @@
+.main-container{
+    margin: 15px;
+    margin-left: 50px;
+    height: 450px;
+    width: 600px;
+    text-align: center;
+}
+
+.content-container{
+    position: relative;
+    overflow: hidden;
+}
+
+.mat-elevation-z8{
+    width: 100%;
+}
+
+.top-line{
+    height: 10px;
+    margin-top: -1px;
+    margin-right: -1px;
+    margin-left: -1px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    background-color: #ff4081;
+}
+
+.bottom-line{
+    height: 10px;
+    margin-top: 1px;
+    margin-right: 1px;
+    margin-left: 1px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    background-color: #12002e;
+}

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.html
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.html
@@ -1,0 +1,10 @@
+<div>
+    <div class="top-line"></div>
+    <mat-card class="main-container">
+        <mat-card-title>Upcoming Booked Appointments</mat-card-title>
+        <mat-card-content>
+            
+        </mat-card-content>
+    </mat-card>
+    <div class="bottom-line"></div>
+</div>

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.html
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.html
@@ -3,7 +3,34 @@
     <mat-card class="main-container">
         <mat-card-title>Upcoming Booked Appointments</mat-card-title>
         <mat-card-content>
-            
+            <div *ngIf="myBookedAppointments === undefined">
+                <h4>No booked appointments found.</h4>
+            </div>
+            <div *ngIf="myBookedAppointments !== undefined">
+                <table mat-table [dataSource]="myBookedAppointments | slice:0:6" class="mat-elevation-z8">
+                    <ng-container matColumnDef="startTime">
+                        <th mat-header-cell *matHeaderCellDef>Start Time</th>
+                        <td mat-cell *matCellDef="let element">{{element.startTime}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="endTime">
+                        <th mat-header-cell *matHeaderCellDef>End Time</th>
+                        <td mat-cell *matCellDef="let element">{{element.endTime}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="title">
+                        <th mat-header-cell *matHeaderCellDef>Title</th>
+                        <td mat-cell *matCellDef="let element">{{element.title}}</td>
+                    </ng-container>
+
+                    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                    <tr mat-row class="element-row"
+                        *matRowDef="let row;
+                        columns: displayedColumns;"
+                        >
+                    </tr>
+                </table>
+            </div>
         </mat-card-content>
     </mat-card>
     <div class="bottom-line"></div>

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.spec.ts
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BookedApptsWidgetComponent } from './booked-appts-widget.component';
+
+describe('BookedApptsWidgetComponent', () => {
+  let component: BookedApptsWidgetComponent;
+  let fixture: ComponentFixture<BookedApptsWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ BookedApptsWidgetComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BookedApptsWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.ts
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-booked-appts-widget',
+  templateUrl: './booked-appts-widget.component.html',
+  styleUrls: ['./booked-appts-widget.component.css']
+})
+export class BookedApptsWidgetComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.ts
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.ts
@@ -1,4 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { ISchedule } from 'src/app/models/interfaces/ISchedule';
+import { IAppointment } from 'src/app/models/interfaces/IAppointment';
+import { IRepeatingAppointment } from 'src/app/models/interfaces/IRepeatingAppointment';
+import { IPage } from 'src/app/models/interfaces/IPage';
+import { ScheduleService } from 'src/app/services/ScheduleService.service';
+import { DateManager } from 'src/app/services/DateManager';
 
 @Component({
   selector: 'app-booked-appts-widget',
@@ -7,9 +13,53 @@ import { Component, OnInit } from '@angular/core';
 })
 export class BookedApptsWidgetComponent implements OnInit {
 
-  constructor() { }
+  myPage: IPage;
+  mySchedules: ISchedule[];
+  myRepeatingAppointments: IRepeatingAppointment[];
+  myBookedAppointments: IAppointment[];
+  displayedColumns: string[] = ['startTime', 'endTime', 'title'];
+
+  constructor(private scheduleService: ScheduleService) { }
 
   ngOnInit(): void {
+    this.getSchedule();
   }
 
+  getSchedule() {
+    this.scheduleService.getAllSchedules().subscribe(
+        data => {
+        this.myPage = data;
+        this.parsePage(this.myPage);
+        }
+    );
+  }
+
+  parsePage(page: IPage) {
+    this.mySchedules = page.content;
+    let repeatingAppts: IRepeatingAppointment[] = [];
+    let appts: IAppointment[] = [];
+
+    // Construct array of RepeatingAppointments
+    this.mySchedules.map(
+      data => {
+        repeatingAppts = data.appointments;
+        this.myRepeatingAppointments = repeatingAppts;
+        return data;
+      }
+    );
+
+    // Construct array of Appointments
+    this.myRepeatingAppointments.map( 
+      data => {
+        // Filtering booked appointments. Those that have 2 participants
+        if(data.appointment.participants[1] !== undefined) {
+          appts.push(data.appointment);
+          this.myBookedAppointments = appts;
+          return data;
+        }
+        return data;
+      }
+    );
+
+  }
 }

--- a/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.ts
+++ b/angular-app/src/app/theme/widgets/booked-appts-widget/booked-appts-widget.component.ts
@@ -19,7 +19,7 @@ export class BookedApptsWidgetComponent implements OnInit {
   myBookedAppointments: IAppointment[];
   displayedColumns: string[] = ['startTime', 'endTime', 'title'];
 
-  constructor(private scheduleService: ScheduleService) { }
+  constructor(private scheduleService: ScheduleService, private dateManager: DateManager) { }
 
   ngOnInit(): void {
     this.getSchedule();
@@ -53,12 +53,19 @@ export class BookedApptsWidgetComponent implements OnInit {
       data => {
         // Filtering booked appointments. Those that have 2 participants
         if(data.appointment.participants[1] !== undefined) {
+          // Converting the date format to be more user friendly
+          let startdate: number[] = data.appointment.startTime as number[];
+          let enddate: number[] = data.appointment.endTime as number[];
+          data.appointment.startTime = this.dateManager.arrayToDate(startdate).toLocaleString();
+          data.appointment.endTime = this.dateManager.arrayToDate(enddate).toLocaleString()
+
           appts.push(data.appointment);
           this.myBookedAppointments = appts;
           return data;
         }
         return data;
-      }
+      },
+  
     );
 
   }


### PR DESCRIPTION
Displaying a widget that shows the top 6 appointments that are booked for the talent account. To test it out:
1. Delete the `schedules.json` file with the test data that is automatically generated
2. Create your schedule on the `schedule-configuration.component`
3. Open the `schedules.json` file and add another participant to the participant array (your email should be the first element in the participant array if you created your schedule using the `schedule-configuration.component`

** This implementation might change to adapt the newer model of generating appointments as this reflects booking appointments through the schedule which I learned is not the intended way **

![PR1](https://user-images.githubusercontent.com/58965151/200202472-08bc648c-aad3-40e2-9332-bba5254d0c74.JPG)
