### PR TITLE
COM286 Filter Appointments Based on Talent Assigned to Them

### DIFF
--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { FormsModule} from "@angular/forms";
 import { HttpClientModule } from '@angular/common/http';
 import { LandingPageConfigurationComponent } from './pages/admin-configuration/landing-page-configuration/landing-page-configuration.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
+import { ParticipantBookedApptsComponent } from './theme/widgets/participant-booked-appts/participant-booked-appts.component';
 import { ParticipantNavComponent } from './pages/nav/participant-nav/participant-nav.component';
 import { ReactiveFormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router';
@@ -73,7 +74,7 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { EventWidgetComponent } from './theme/widgets/event-widget/event-widget.component';
-import { ParticipantBookedApptsComponent } from './theme/widgets/participant-booked-appts/participant-booked-appts.component';
+
 
 
 @NgModule({
@@ -93,8 +94,11 @@ import { ParticipantBookedApptsComponent } from './theme/widgets/participant-boo
     CalenderViewComponent,
     CustomBannerDirective,
     DefaultHeaderComponent,
+    EventWidgetComponent,
     LandingPageConfigurationComponent,
     PageNotFoundComponent,
+    ParticipantBookedApptsComponent,
+    ParticipantNavComponent,
     ScheduleConfigurationComponent,
     SetupWizardComponent,
     SignInComponent,
@@ -106,9 +110,6 @@ import { ParticipantBookedApptsComponent } from './theme/widgets/participant-boo
     AccountModalComponent,
     TalentNavComponent,
     AdminNavComponent,
-    ParticipantNavComponent,
-    EventWidgetComponent,
-    ParticipantBookedApptsComponent,
   ],
   imports: [
     AppRoutingModule,
@@ -144,8 +145,8 @@ import { ParticipantBookedApptsComponent } from './theme/widgets/participant-boo
       { path: 'admin-panel', component: AdminPanelComponent },
       { path: 'admin-panel-test', component: AdminPanelComponent },
       { path: 'appointment-details', component: AppointmentDetailsComponent },
-      {path:'appointment',component:AppointmentComponent},
-      {path:'appointment-creation',component:AppointmentCreateFormComponent},
+      { path: 'appointment', component: AppointmentComponent},
+      { path: 'appointment-creation', component: AppointmentCreateFormComponent},
       { path: 'booking-page', component: BookingPageComponent },
       { path: 'landing-page-component', component: LandingPageConfigurationComponent },
       { path: 'schedule-configuration', component: ScheduleConfigurationComponent },

--- a/angular-app/src/app/pages/appointments/appointment-details/appointment-details.component.ts
+++ b/angular-app/src/app/pages/appointments/appointment-details/appointment-details.component.ts
@@ -9,6 +9,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { IUser } from 'src/app/models/interfaces/IUser';
 import { IUserResponse } from 'src/app/models/interfaces/IUserResponse';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-appointment-details',
@@ -18,6 +19,7 @@ import { IUserResponse } from 'src/app/models/interfaces/IUserResponse';
 export class AppointmentDetailsComponent {
 
   dateApptDictionary = new Map<string, any[]>();
+  filterApptName;
   allAppointments;
   allDates;
   userEmail;
@@ -31,10 +33,11 @@ export class AppointmentDetailsComponent {
 
   constructor(private appointmentService: AppointmentService, private dateManager: DateManager,
     private authenticationService: AuthenticationService, private userService: UserService, private snackBar: MatSnackBar,
-    private formBuilder: FormBuilder) {
+    private formBuilder: FormBuilder, private activatedRoute: ActivatedRoute) {
     this.checkIfAuthenticated();
     this.checkIfRegisteredWithVendia();
     this.getAppointments();
+    this.activatedRoute.queryParams.subscribe( data => { this.filterApptName = data['event']; console.log(this.filterApptName); } );
     this.userBookingForm = this.formBuilder.group({
       email: ['', Validators.required],
     });
@@ -49,8 +52,15 @@ export class AppointmentDetailsComponent {
             appt.startTime = this.dateManager.arrayToDate(appt.startTime as number[]);
             appt.endTime = this.dateManager.arrayToDate(appt.endTime as number[]);
           }
-        )
+        );
         this.allAppointments = data;
+        // When we it recognizes there is a query param, we will apply the title filter
+        if(this.filterApptName) {
+          let newAppts: IAppointment[] = [];
+          newAppts = this.findByApptTitle(this.allAppointments);
+          console.log(newAppts);
+          this.allAppointments = newAppts;
+        }
         this.getDates(this.allAppointments);
       }
     );
@@ -191,8 +201,18 @@ export class AppointmentDetailsComponent {
         console.log(data);
       }
     );
-    
-    
+  }
 
+  findByApptTitle(appts: IAppointment[]) {
+    let newAppts: IAppointment[] = [];
+    if(this.filterApptName) {
+      for(let i = 0; i < appts.length; i++) {
+        if(appts[i].title == this.filterApptName) {
+          newAppts.push(appts[i]);
+        }
+      }
+    }
+   
+    return newAppts;
   }
 }

--- a/angular-app/src/app/theme/widgets/event-widget/event-widget.component.html
+++ b/angular-app/src/app/theme/widgets/event-widget/event-widget.component.html
@@ -31,8 +31,13 @@
             <div class="break"></div>
         </mat-card-content>
         <mat-card-actions class="mat-card-actions">
+            <div *ngIf="(hasEvent ===  true)" class="first-button">
+                <a  routerLink="../appointment-details" [queryParams]="{event : appointmentName}" routerLinkActive="active">
+                    <button mat-raised-button color="primary">Booking Page</button>
+                </a>
+            </div>
             <div class="first-button">
-                <a routerLink="../booking-page" routerLinkActive="active">
+                <a *ngIf="(hasEvent ===  false)" routerLink="../appointment-details" routerLinkActive="active">
                     <button mat-raised-button color="primary">Booking Page</button>
                 </a>
             </div>

--- a/angular-app/src/app/theme/widgets/event-widget/event-widget.component.ts
+++ b/angular-app/src/app/theme/widgets/event-widget/event-widget.component.ts
@@ -14,6 +14,7 @@ import { MatIconRegistry } from "@angular/material/icon";
 export class EventWidgetComponent implements OnInit {
 
   myPage: IPage;
+  appointmentName;
   eventName;
   eventDuration;
   hasEvent = false;
@@ -40,12 +41,14 @@ export class EventWidgetComponent implements OnInit {
     );
   }
 
+  // This function is only supporting 1 schedule right now
   private parsePage(page: IPage) {
     this.eventName = page.content[0].name;
     if (this.eventName == '') {
       this.hasEvent = false;
     } else {
       this.hasEvent = true;
+      this.appointmentName = page.content[0].appointments[0].appointment.title;
     }
   }
 


### PR DESCRIPTION
Added functionality to filter the `appointment-details` page to filter by a particular query parameter.

Clicking on an event on the dashboard will now navigate to this page with a filter applied so we don't always see every appointment we have saved in Vendia.

![PR1](https://user-images.githubusercontent.com/58965151/202036507-db86a931-da0a-47c5-8ba7-c51a8141c467.JPG)

![PR2](https://user-images.githubusercontent.com/58965151/202036801-2fbe80f1-c9cd-4c0a-98b4-5be4ce0092ce.JPG)



