### PR TITLE
Changing the Text on the Update Role Button in Admin Panel

### DIFF
--- a/angular-app/src/app/pages/admin-panel/admin-panel/admin-panel.component.html
+++ b/angular-app/src/app/pages/admin-panel/admin-panel/admin-panel.component.html
@@ -38,7 +38,7 @@
                         </mat-select>
                     </mat-form-field>
                     <button mat-raised-button class="action-button" (click)="changeUserRole(changeRoleForm.value, user)" [disabled]="!changeRoleForm.valid">
-                      Book Selected User
+                      Change User's Role
                     </button>
                 </form>
 


### PR DESCRIPTION
Noticed the button in the update role page read "Book user" instead of "Update Role". Super quick fix.

Before:
![PR1](https://user-images.githubusercontent.com/58965151/204109615-31cfe145-53a3-4506-b890-6256d2e2cdd7.JPG)

After:
![PR2](https://user-images.githubusercontent.com/58965151/204109623-0c6954cf-c9ad-49b4-8c51-4b7b0c0ea705.JPG)
