### PR TITLE
COM 293 Fix the Signup Modal From Displaying Twice

### DIFF
--- a/angular-app/src/app/pages/dashboard/splash/splash.component.ts
+++ b/angular-app/src/app/pages/dashboard/splash/splash.component.ts
@@ -94,7 +94,6 @@ export class SplashComponent implements OnInit {
       data => { 
         this.isRegisteredValue = data;
         this.getUserEmail();
-        this.updateShouldDisplayModal(this.isRegisteredValue, this.userEmail); 
     });
   }
 
@@ -106,7 +105,7 @@ export class SplashComponent implements OnInit {
   }
 
   updateShouldDisplayModal(newRegisteredValue: boolean, email: string): void {
-    if(this.shouldDisplayModal = (this.isAuthenticatedValue && newRegisteredValue === false) && email !== undefined){
+    if(this.shouldDisplayModal = (this.isAuthenticatedValue && newRegisteredValue === false) && (email !== undefined || email != '')){
       this.displayModal(email);
     }
   }

--- a/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
+++ b/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
@@ -53,10 +53,10 @@ export class SignupModalComponent implements OnInit {
     console.log("The value of data is: " + data);
     const newUser: IUser = {
       _id: uuidv4(),
-      displayName: data.displayName, // these are returning empty the first click
+      displayName: data.displayName,
       email: this.userEmailValue,
       role: "PARTICIPANT" as UserRole,
-      phoneNumber: "+1" + data.phoneNumber
+      phoneNumber: data.phoneNumber ? "+1" + data.phoneNumber : '',
     }
     
     // Will need to add error handling and a spinner animation here later

--- a/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
+++ b/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
@@ -50,7 +50,6 @@ export class SignupModalComponent implements OnInit {
   }
    
   onClickSubmit(data): void {
-    console.log("The value of data is: " + data);
     const newUser: IUser = {
       _id: uuidv4(),
       displayName: data.displayName,

--- a/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
+++ b/angular-app/src/app/theme/modals/signup-modal/signup-modal.component.ts
@@ -18,9 +18,7 @@ export class SignupModalComponent implements OnInit {
     Validators.pattern("^(\\+\\d{1,2}\\s?)?1?\\-?\\.?\\s?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}$")
   ];
 
-  constructor (@Inject(MAT_DIALOG_DATA) public data: { userEmailValue: string}, private userService: UserService, public dialogRef: MatDialogRef<SignupModalComponent>) { }
-
-  ngOnInit() {
+  constructor (@Inject(MAT_DIALOG_DATA) public data: { userEmailValue: string}, private userService: UserService, public dialogRef: MatDialogRef<SignupModalComponent>) {
     this.profileForm = new FormGroup({
       displayName: new FormControl ('', [ Validators.required ]),
       confirmDisplayName: new FormControl('', [ Validators.required ]),
@@ -34,7 +32,10 @@ export class SignupModalComponent implements OnInit {
     );
 
     this.userEmailValue = this.data.userEmailValue;
+
   }
+
+  ngOnInit() { }
 
   getDisplayName() {
     return this.profileForm.get('displayName');
@@ -49,9 +50,10 @@ export class SignupModalComponent implements OnInit {
   }
    
   onClickSubmit(data): void {
+    console.log("The value of data is: " + data);
     const newUser: IUser = {
       _id: uuidv4(),
-      displayName: data.displayName,
+      displayName: data.displayName, // these are returning empty the first click
       email: this.userEmailValue,
       role: "PARTICIPANT" as UserRole,
       phoneNumber: "+1" + data.phoneNumber


### PR DESCRIPTION
Originally the splash page checked twice if the conditions required to open the modal were met. I omitted checking the condition right after verifying the user is not in Vendia and waited until we got their email to prevent a modal with empty email field being opened.

Also fixed an issue with the phone number field saving "+1" in all forms. If no phone number is provided, an empty string will be added instead of "+1".